### PR TITLE
ci: Node 24 Actions runtimes and release 0.9.1

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,9 +27,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -40,9 +40,9 @@ jobs:
   packaging-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: "npm"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,12 +17,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           registry-url: "https://registry.npmjs.org/"
+          package-manager-cache: false
       - run: npm ci
       - run: npm run build --if-present
       - name: Verify package contents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
 
@@ -108,7 +108,7 @@ jobs:
           sha256sum ${{ matrix.binary-name }} > ${{ matrix.binary-name }}.sha256
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.binary-name }}
           path: |
@@ -124,10 +124,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 
@@ -246,7 +246,7 @@ jobs:
           VERSION: ${{ steps.tag_version.outputs.version }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: release-assets/*
           name: Release v${{ steps.tag_version.outputs.version }}

--- a/.github/workflows/snap-release.yml
+++ b/.github/workflows/snap-release.yml
@@ -20,10 +20,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: npm
@@ -64,7 +64,7 @@ jobs:
           echo "Snap file: $SNAP_FILE"
 
       - name: Upload snap artifact to GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ steps.snap_file.outputs.file }}
         env:

--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ macOS:
 
 ```sh
 # Apple Silicon
-curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.0/ipb-macos-arm64 -o ipb
+curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.1/ipb-macos-arm64 -o ipb
 chmod +x ipb
 sudo mv ipb /usr/local/bin/
 
 # Intel
-curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.0/ipb-macos-x64 -o ipb
+curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.1/ipb-macos-x64 -o ipb
 chmod +x ipb
 sudo mv ipb /usr/local/bin/
 ```
@@ -150,15 +150,15 @@ sudo mv ipb /usr/local/bin/
 Linux (.deb):
 
 ```sh
-wget https://github.com/devinpearson/ipb/releases/download/v0.9.0/ipb_0.9.0_amd64.deb
-sudo dpkg -i ipb_0.9.0_amd64.deb
+wget https://github.com/devinpearson/ipb/releases/download/v0.9.1/ipb_0.9.1_amd64.deb
+sudo dpkg -i ipb_0.9.1_amd64.deb
 sudo apt-get install -f
 ```
 
 Linux binary:
 
 ```sh
-curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.0/ipb-linux-x64 -o ipb
+curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.1/ipb-linux-x64 -o ipb
 # or: ipb-linux-arm64
 chmod +x ipb
 sudo mv ipb /usr/local/bin/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "investec-ipb",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "investec-ipb",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "investec-ipb",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "bin/index.js",
   "bin": {
     "ipb": "./bin/index.js"


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions (`checkout`/`setup-node`/`artifact`/`gh-release`) to Node 24 runtimes
- Bump package version to **0.9.1** and update README download URLs

## Test plan
- [ ] CI passes without Node 20 action runtime warnings
- [ ] `npm run build && node bin/index.js --version` prints `0.9.1`