### PR TITLE
ci: npm trusted publishing and release 0.9.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing git tag to publish (e.g. v0.9.1). Leave empty to use the triggering ref.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -18,16 +24,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Allow re-publishing a tag after trusted publishing is configured.
+          ref: ${{ inputs.tag || github.ref }}
+
       - name: Use Node.js 24.x
         uses: actions/setup-node@v5
         with:
           node-version: 24.x
-          registry-url: "https://registry.npmjs.org/"
+          registry-url: https://registry.npmjs.org/
           package-manager-cache: false
+
       - run: npm ci
       - run: npm run build --if-present
       - name: Verify package contents
         run: npm pack --dry-run
-      - run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Auth via npm Trusted Publishing (OIDC). No long-lived NPM_TOKEN required.
+      # Provenance is generated automatically for trusted publishes; --provenance is kept for clarity.
+      - name: Publish to npm
+        run: npm publish --access public --provenance

--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ macOS:
 
 ```sh
 # Apple Silicon
-curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.1/ipb-macos-arm64 -o ipb
+curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.2/ipb-macos-arm64 -o ipb
 chmod +x ipb
 sudo mv ipb /usr/local/bin/
 
 # Intel
-curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.1/ipb-macos-x64 -o ipb
+curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.2/ipb-macos-x64 -o ipb
 chmod +x ipb
 sudo mv ipb /usr/local/bin/
 ```
@@ -150,15 +150,15 @@ sudo mv ipb /usr/local/bin/
 Linux (.deb):
 
 ```sh
-wget https://github.com/devinpearson/ipb/releases/download/v0.9.1/ipb_0.9.1_amd64.deb
-sudo dpkg -i ipb_0.9.1_amd64.deb
+wget https://github.com/devinpearson/ipb/releases/download/v0.9.2/ipb_0.9.2_amd64.deb
+sudo dpkg -i ipb_0.9.2_amd64.deb
 sudo apt-get install -f
 ```
 
 Linux binary:
 
 ```sh
-curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.1/ipb-linux-x64 -o ipb
+curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.2/ipb-linux-x64 -o ipb
 # or: ipb-linux-arm64
 chmod +x ipb
 sudo mv ipb /usr/local/bin/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "investec-ipb",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "investec-ipb",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "investec-ipb",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": "bin/index.js",
   "bin": {
     "ipb": "./bin/index.js"


### PR DESCRIPTION
## Summary
- Publish with npm **Trusted Publishing** (OIDC) instead of long-lived `NPM_TOKEN`
- Add `workflow_dispatch` so a tag can be re-published after trusted publisher setup
- Bump version to **0.9.2** and update README download URLs

## Test plan
- [ ] Merge this PR
- [ ] Tag and push `v0.9.2` (or run **Publish to npm** with tag `v0.9.2`)
- [ ] `npm view investec-ipb version` shows `0.9.2`