### PR TITLE
fix: snapcraft/Windows release and bump to 0.9.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,15 @@ jobs:
       - name: Bundle with esbuild
         run: npm run bundle
 
+      - name: Verify bundle output
+        shell: bash
+        run: |
+          test -f dist-bundle/index.cjs || {
+            echo "dist-bundle/index.cjs was not produced by npm run bundle"
+            ls -la dist-bundle || true
+            exit 1
+          }
+
       - name: Package binary
         run: npx pkg dist-bundle/index.cjs --targets ${{ matrix.target }} --out-path dist --no-bytecode --public
 

--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ macOS:
 
 ```sh
 # Apple Silicon
-curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.2/ipb-macos-arm64 -o ipb
+curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.3/ipb-macos-arm64 -o ipb
 chmod +x ipb
 sudo mv ipb /usr/local/bin/
 
 # Intel
-curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.2/ipb-macos-x64 -o ipb
+curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.3/ipb-macos-x64 -o ipb
 chmod +x ipb
 sudo mv ipb /usr/local/bin/
 ```
@@ -150,15 +150,15 @@ sudo mv ipb /usr/local/bin/
 Linux (.deb):
 
 ```sh
-wget https://github.com/devinpearson/ipb/releases/download/v0.9.2/ipb_0.9.2_amd64.deb
-sudo dpkg -i ipb_0.9.2_amd64.deb
+wget https://github.com/devinpearson/ipb/releases/download/v0.9.3/ipb_0.9.3_amd64.deb
+sudo dpkg -i ipb_0.9.3_amd64.deb
 sudo apt-get install -f
 ```
 
 Linux binary:
 
 ```sh
-curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.2/ipb-linux-x64 -o ipb
+curl -L https://github.com/devinpearson/ipb/releases/download/v0.9.3/ipb-linux-x64 -o ipb
 # or: ipb-linux-arm64
 chmod +x ipb
 sudo mv ipb /usr/local/bin/

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -2,7 +2,7 @@
 import { promises as fs } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 // esbuild configuration for bundling the CLI application
 import { build } from 'esbuild';
 
@@ -103,8 +103,9 @@ async function buildApp(options = {}) {
   }
 }
 
-// Run if called directly
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Run if called directly (pathToFileURL is required for Windows path matching)
+const entryHref = process.argv[1] ? pathToFileURL(process.argv[1]).href : '';
+if (import.meta.url === entryHref) {
   const args = process.argv.slice(2);
   const minify = args.includes('--minify');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "investec-ipb",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "investec-ipb",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "investec-ipb",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "main": "bin/index.js",
   "bin": {
     "ipb": "./bin/index.js"

--- a/scripts/create-snap.sh
+++ b/scripts/create-snap.sh
@@ -6,6 +6,8 @@
 set -euo pipefail
 
 VERSION=${1:-$(node -p "require('./package.json').version")}
+# Strip leading v if present (tags are often v0.9.2)
+VERSION=${VERSION#v}
 SNAPCRAFT_FILE="snap/snapcraft.yaml"
 
 if [ ! -f "$SNAPCRAFT_FILE" ]; then
@@ -18,21 +20,34 @@ echo "Creating snap package for IPB v${VERSION}..."
 if [ ! -f "dist/ipb-linux-x64" ]; then
   echo "Linux binary not found, building first..."
   npm run pkg:linux
+  if [ -f "dist/investec-ipb-linux-x64" ]; then
+    mv dist/investec-ipb-linux-x64 dist/ipb-linux-x64
+  elif [ -f "dist/index" ]; then
+    mv dist/index dist/ipb-linux-x64
+  fi
+  chmod +x dist/ipb-linux-x64
 fi
 
-TMP_FILE=$(mktemp)
-cp "$SNAPCRAFT_FILE" "$TMP_FILE"
+# Update version in snapcraft.yaml, restore on exit
+ORIGINAL_VERSION=$(sed -n "s/^version: ['\"]\\(.*\\)['\"]/\\1/p" "$SNAPCRAFT_FILE" | head -n 1)
+restore_version() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/^version: .*/version: '${ORIGINAL_VERSION}'/" "$SNAPCRAFT_FILE"
+  else
+    sed -i "s/^version: .*/version: '${ORIGINAL_VERSION}'/" "$SNAPCRAFT_FILE"
+  fi
+}
+trap restore_version EXIT
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' "s/^version: .*/version: '${VERSION}'/" "$TMP_FILE"
+  sed -i '' "s/^version: .*/version: '${VERSION}'/" "$SNAPCRAFT_FILE"
 else
-  sed -i "s/^version: .*/version: '${VERSION}'/" "$TMP_FILE"
+  sed -i "s/^version: .*/version: '${VERSION}'/" "$SNAPCRAFT_FILE"
 fi
 
-echo "Running snapcraft build..."
-snapcraft --destructive-mode --project-dir "$(pwd)" --snapcraft-yaml "$TMP_FILE"
-
-rm -f "$TMP_FILE"
+echo "Running snapcraft pack (destructive mode)..."
+# Modern snapcraft requires `pack`; --snapcraft-yaml/--project-dir were removed.
+snapcraft pack --destructive-mode
 
 echo ""
 echo "Snap build complete."

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ipb
-version: '0.8.3'
+version: '0.9.3'
 summary: CLI application to manage Investec Programmable Banking cards
 description: |
   A command-line interface for managing and deploying code to Investec

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,7 @@ base: core24
 
 apps:
   ipb:
-    command: ipb
+    command: usr/bin/ipb
     plugs:
       - network
       - home


### PR DESCRIPTION
## Summary
- Fix snap build for current snapcraft CLI (`snapcraft pack --destructive-mode`)
- Fix Windows esbuild entrypoint so `pkg` finds `dist-bundle/index.cjs`
- Bump version to **0.9.3**

## Test plan
- [ ] Merge this PR
- [ ] Tag and push `v0.9.3`
- [ ] Release Binaries Windows job succeeds
- [ ] Snap job produces `ipb_0.9.3_*.snap`
- [ ] `npm view investec-ipb version` is `0.9.3`