### PR TITLE
fix: use bash for Windows release rename step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
 
       - name: Rename binary (Windows)
         if: matrix.platform == 'win'
+        shell: bash
         run: |
           cd dist
           # pkg creates binaries with package name
@@ -100,6 +101,10 @@ jobs:
             mv investec-ipb-win-x64.exe ${{ matrix.binary-name }}
           elif [ -f "index.exe" ]; then
             mv index.exe ${{ matrix.binary-name }}
+          else
+            echo "Expected Windows binary not found in dist/"
+            ls -la
+            exit 1
           fi
 
       - name: Calculate SHA256 checksum (macOS/Linux)


### PR DESCRIPTION
## Summary
- Force `shell: bash` on the Windows binary rename step so POSIX `if [ -f ... ]` works on `windows-latest` (default PowerShell was failing with `Missing '(' after 'if'`)

## Test plan
- [ ] Re-run **Release Binaries** for `v0.9.3` (or tag a new patch)
- [ ] Windows matrix job completes rename + checksum + artifact upload


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows release packaging by reliably identifying the expected binary.
  * Release builds now provide clearer diagnostics when the Windows binary is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->