### PR TITLE
fix: Snap Store credentials and investec-ipb snap name

### DIFF
--- a/.github/workflows/snap-release.yml
+++ b/.github/workflows/snap-release.yml
@@ -78,6 +78,17 @@ jobs:
             echo "SNAPCRAFT_STORE_CREDENTIALS not configured, skipping Snap Store upload."
             exit 0
           fi
-          mkdir -p "$HOME/.snapcraft"
-          printf "%s" "$SNAPCRAFT_STORE_CREDENTIALS" | base64 -d > "$HOME/.snapcraft/snapcraft.cfg"
+
+          # Snapcraft 7+ reads Ubuntu One credentials from SNAPCRAFT_STORE_CREDENTIALS
+          # (output of `snapcraft export-login`). Do not write ~/.snapcraft/snapcraft.cfg.
+          #
+          # Support secrets stored either as raw export-login text or base64 of that text.
+          CREDS="$SNAPCRAFT_STORE_CREDENTIALS"
+          if [[ "$CREDS" != \{* ]]; then
+            if DECODED=$(printf '%s' "$CREDS" | base64 -d 2>/dev/null) && [[ "$DECODED" == \{* ]]; then
+              CREDS="$DECODED"
+            fi
+          fi
+          export SNAPCRAFT_STORE_CREDENTIALS="$CREDS"
+
           snapcraft upload --release=stable "${{ steps.snap_file.outputs.file }}"

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -312,7 +312,7 @@ sudo snap install snapcraft --classic
 snapcraft
 
 # Install
-sudo snap install ipb_0.8.3_amd64.snap --dangerous
+sudo snap install investec-ipb_0.8.3_amd64.snap --dangerous
 ```
 
 See `snap/snapcraft.yaml` for configuration.

--- a/UBUNTU_DISTRIBUTION.md
+++ b/UBUNTU_DISTRIBUTION.md
@@ -189,28 +189,27 @@ when `SNAPCRAFT_STORE_CREDENTIALS` is configured.
 2. Export CI credentials (replace values as needed):
 
    ```bash
-   snapcraft export-login --snaps ipb --channels stable snapcraft-login.txt
+   snapcraft export-login \
+     --snaps ipb \
+     --acls package_access,package_push,package_update,package_release \
+     --channels stable \
+     snapcraft-login.txt
    ```
 
-3. Base64-encode the file (single line output):
-
-   ```bash
-   base64 -w 0 snapcraft-login.txt
-   ```
-
-   On macOS, use:
-
-   ```bash
-   base64 -i snapcraft-login.txt | tr -d '\n'
-   ```
-
-4. In GitHub, add a repository secret:
+3. In GitHub, add a repository secret:
    - Name: `SNAPCRAFT_STORE_CREDENTIALS`
-   - Value: the base64 output from step 3
-5. Push a release tag (for example `v0.8.4`) to trigger automatic build + publish.
+   - Value: the **raw contents** of `snapcraft-login.txt` (not a password; not written to `snapcraft.cfg`)
+
+   Base64-encoding the file is optional; the workflow accepts either raw or base64-encoded
+   export-login output.
+
+4. Push a release tag (for example `v0.9.3`) to trigger automatic build + publish.
 
 If the secret is not set, the workflow still builds the `.snap` file and uploads it to
 the GitHub Release, but skips Snap Store publishing.
+
+Snapcraft 7+ authenticates only via `SNAPCRAFT_STORE_CREDENTIALS` (or interactive login).
+Do not use `snapcraft login --with` in CI.
 
 ## Method 4: AppImage
 

--- a/UBUNTU_DISTRIBUTION.md
+++ b/UBUNTU_DISTRIBUTION.md
@@ -160,20 +160,21 @@ npm run pkg:linux
 # Build snap
 snapcraft
 
-# Result: ipb_0.8.3_amd64.snap
+# Result: investec-ipb_0.9.3_amd64.snap
 ```
 
 ### Installing Snap
 
 ```bash
-sudo snap install ipb_0.8.3_amd64.snap --dangerous
+sudo snap install investec-ipb_0.9.3_amd64.snap --dangerous
 ```
 
 ### Publishing to Snap Store
 
 1. Register at [Snap Store](https://snapcraft.io)
-2. Upload snap: `snapcraft upload --release=stable ipb_0.8.3_amd64.snap`
-3. Users install: `sudo snap install ipb`
+2. Register the snap name (once): `snapcraft register investec-ipb`
+3. Upload snap: `snapcraft upload --release=stable investec-ipb_0.9.3_amd64.snap`
+4. Users install: `sudo snap install investec-ipb`
 
 ### GitHub Actions: Automatic Snap Store Publish
 
@@ -190,7 +191,7 @@ when `SNAPCRAFT_STORE_CREDENTIALS` is configured.
 
    ```bash
    snapcraft export-login \
-     --snaps ipb \
+     --snaps investec-ipb \
      --acls package_access,package_push,package_update,package_release \
      --channels stable \
      snapcraft-login.txt

--- a/scripts/create-snap.sh
+++ b/scripts/create-snap.sh
@@ -52,4 +52,5 @@ snapcraft pack --destructive-mode
 echo ""
 echo "Snap build complete."
 echo "Install locally with:"
-echo "  sudo snap install ipb_${VERSION}_amd64.snap --dangerous"
+echo "  sudo snap install investec-ipb_${VERSION}_amd64.snap --dangerous"
+echo "Then run: investec-ipb --version"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: ipb
+name: investec-ipb
 version: '0.9.3'
 summary: CLI application to manage Investec Programmable Banking cards
 description: |
@@ -7,18 +7,18 @@ description: |
   transaction management, and account operations.
   
   Features:
-  - Deploy JavaScript code to programmable cards
-  - Local code emulation and testing
-  - Transaction log retrieval
-  - Account and balance management
-  - Environment variable management
+    - Deploy JavaScript code to programmable cards
+    - Local code emulation and testing
+    - Transaction log retrieval
+    - Account and balance management
+    - Environment variable management
 
 grade: stable
 confinement: strict
 base: core24
 
 apps:
-  ipb:
+  investec-ipb:
     command: usr/bin/ipb
     plugs:
       - network


### PR DESCRIPTION
## Summary
- Pass Snap Store auth via `SNAPCRAFT_STORE_CREDENTIALS` (Snapcraft 7+)
- Rename the snap package to **investec-ipb** to match the registered Snap Store name
- Update docs / export-login examples accordingly

## Test plan
- [ ] `./scripts/create-snap.sh 0.9.3` produces `investec-ipb_0.9.3_amd64.snap`
- [ ] `snapcraft upload --release=stable investec-ipb_0.9.3_amd64.snap` succeeds
- [ ] Refresh `SNAPCRAFT_STORE_CREDENTIALS` with `--snaps investec-ipb` if CI upload is used