### PR TITLE
fix: MAU response shape handling (0.10.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "investec-ipb",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "investec-ipb",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.9.0",
@@ -15,7 +15,7 @@
         "commander": "^14.0.2",
         "dotenv": "^17.2.3",
         "investec-card-api": "^0.2.3",
-        "investec-mau-api": "^0.1.0",
+        "investec-mau-api": "^0.1.1",
         "investec-pb-api": "^0.3.12",
         "js-yaml": "^4.3.1",
         "node-fetch": "^3.3.2",
@@ -3562,9 +3562,9 @@
       }
     },
     "node_modules/investec-mau-api": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/investec-mau-api/-/investec-mau-api-0.1.0.tgz",
-      "integrity": "sha512-lQsl18XxrJnhariKknyrXsZZdNKCinUJx1B4Ok2p0tFqc3095OnBapvcnQj+6xjqWDYereNnxMiRXE2KAut3Dw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/investec-mau-api/-/investec-mau-api-0.1.1.tgz",
+      "integrity": "sha512-7BmF97EtXmGfCjHfLp6y1RU9KeQnnZ69FmnwM/5ch2K9rhZG8J0ISnT1204aUGuAM3Wj7MB55q1qFC1FeaPT2g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "investec-ipb",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "bin/index.js",
   "bin": {
     "ipb": "./bin/index.js"
@@ -66,7 +66,7 @@
     "commander": "^14.0.2",
     "dotenv": "^17.2.3",
     "investec-card-api": "^0.2.3",
-    "investec-mau-api": "^0.1.0",
+    "investec-mau-api": "^0.1.1",
     "investec-pb-api": "^0.3.12",
     "js-yaml": "^4.3.1",
     "node-fetch": "^3.3.2",

--- a/src/cmds/mau/accounts.ts
+++ b/src/cmds/mau/accounts.ts
@@ -9,6 +9,7 @@ import {
   withSpinner,
 } from '../../utils.js';
 import type { MauOptions } from '../types.js';
+import { extractMauAccounts } from './helpers.js';
 
 /**
  * List Mauritius (MAU) Investec accounts.
@@ -45,7 +46,7 @@ export async function mauAccountsCommand(options: MauOptions) {
       maxRetries: 3,
       verbose,
     });
-    accounts = result.data.accounts;
+    accounts = extractMauAccounts(result);
   });
 
   await runListCommand({

--- a/src/cmds/mau/balances.ts
+++ b/src/cmds/mau/balances.ts
@@ -10,7 +10,7 @@ import {
   withSpinner,
 } from '../../utils.js';
 import type { MauOptions } from '../types.js';
-import { extractMauRecord, resolveMauAccountId } from './helpers.js';
+import { extractMauBalance, resolveMauAccountId } from './helpers.js';
 
 /**
  * Fetch and display Mauritius (MAU) account balances.
@@ -53,7 +53,7 @@ export async function mauBalancesCommand(accountId: string, options: MauOptions)
       maxRetries: 3,
       verbose,
     });
-    balance = extractMauRecord(result);
+    balance = extractMauBalance(result);
   });
 
   if (!balance) {

--- a/src/cmds/mau/balances.ts
+++ b/src/cmds/mau/balances.ts
@@ -10,7 +10,7 @@ import {
   withSpinner,
 } from '../../utils.js';
 import type { MauOptions } from '../types.js';
-import { resolveMauAccountId } from './helpers.js';
+import { extractMauRecord, resolveMauAccountId } from './helpers.js';
 
 /**
  * Fetch and display Mauritius (MAU) account balances.
@@ -53,7 +53,7 @@ export async function mauBalancesCommand(accountId: string, options: MauOptions)
       maxRetries: 3,
       verbose,
     });
-    balance = result.data;
+    balance = extractMauRecord(result);
   });
 
   if (!balance) {

--- a/src/cmds/mau/documents.ts
+++ b/src/cmds/mau/documents.ts
@@ -11,7 +11,7 @@ import {
   withSpinner,
 } from '../../utils.js';
 import type { MauOptions } from '../types.js';
-import { resolveMauAccountId } from './helpers.js';
+import { normalizeToArray, resolveMauAccountId } from './helpers.js';
 
 interface MauDocumentsOptions extends MauOptions {
   from?: string;
@@ -51,8 +51,13 @@ export async function mauDocumentsCommand(accountId: string, options: MauDocumen
       maxRetries: 3,
       verbose,
     });
-    const accountNumber = result.availableDocuments.accountNumber;
-    documents = result.availableDocuments.documentInformation.map((doc) => ({
+    const available = result.availableDocuments;
+    const accountNumber = available?.accountNumber ?? '';
+    const documentInformation = normalizeToArray<{
+      documentDate: string;
+      documentType: string;
+    }>(available?.documentInformation);
+    documents = documentInformation.map((doc) => ({
       documentDate: doc.documentDate,
       documentType: doc.documentType,
       accountNumber,

--- a/src/cmds/mau/documents.ts
+++ b/src/cmds/mau/documents.ts
@@ -51,7 +51,19 @@ export async function mauDocumentsCommand(accountId: string, options: MauDocumen
       maxRetries: 3,
       verbose,
     });
-    const available = result.availableDocuments;
+    const root = result as {
+      availableDocuments?: {
+        accountNumber?: string;
+        documentInformation?: unknown;
+      };
+      data?: {
+        availableDocuments?: {
+          accountNumber?: string;
+          documentInformation?: unknown;
+        };
+      };
+    };
+    const available = root.availableDocuments ?? root.data?.availableDocuments;
     const accountNumber = available?.accountNumber ?? '';
     const documentInformation = normalizeToArray<{
       documentDate: string;

--- a/src/cmds/mau/helpers.ts
+++ b/src/cmds/mau/helpers.ts
@@ -96,26 +96,66 @@ export function extractMauDataList<T extends object>(result: unknown, field: str
 }
 
 /**
- * Extracts a single MAU record (e.g. balance) from `{ data: {...} }` or a bare object.
+ * Returns true when value looks like a MAU balance record.
+ */
+function looksLikeBalanceRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    ('accountNumber' in value || 'availableBalance' in value || 'accountShortName' in value)
+  );
+}
+
+/**
+ * Extracts a MAU balance record from documented and live response shapes.
+ * Live Mauritius balance payloads often look like `{ accounts: { balance: {...} } }`
+ * (with or without a `data` wrapper) instead of `{ data: { accountNumber, ... } }`.
+ * @param result - Raw getAccountBalances response
+ */
+export function extractMauBalance<T extends object>(result: unknown): T | undefined {
+  if (!result || typeof result !== 'object') {
+    return undefined;
+  }
+
+  const candidates: unknown[] = [result];
+  const data = (result as { data?: unknown }).data;
+  if (data !== undefined) {
+    candidates.push(data);
+  }
+
+  for (const candidate of candidates) {
+    if (looksLikeBalanceRecord(candidate)) {
+      return candidate as T;
+    }
+
+    const accounts = readNamedField(candidate, 'accounts');
+    const nestedBalance = readNamedField(accounts, 'balance');
+    if (looksLikeBalanceRecord(nestedBalance)) {
+      return nestedBalance as T;
+    }
+
+    // accounts may itself be the balance object in some payloads
+    if (looksLikeBalanceRecord(accounts)) {
+      return accounts as T;
+    }
+
+    const directBalance = readNamedField(candidate, 'balance');
+    if (looksLikeBalanceRecord(directBalance)) {
+      return directBalance as T;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Extracts a single MAU record (generic) from `{ data: {...} }` or a bare object.
+ * Prefer {@link extractMauBalance} for balance endpoints.
  * @param result - Raw API response
  */
 export function extractMauRecord<T extends object>(result: unknown): T | undefined {
-  if (!result || typeof result !== 'object' || Array.isArray(result)) {
-    return undefined;
-  }
-  const data = (result as { data?: unknown }).data;
-  if (data && typeof data === 'object' && !Array.isArray(data)) {
-    // Prefer nested data when it looks like the record (not a list wrapper)
-    const record = data as Record<string, unknown>;
-    if (!('accounts' in record) && !('transactions' in record)) {
-      return data as T;
-    }
-  }
-  const root = result as Record<string, unknown>;
-  if ('accountNumber' in root || 'balance' in root || 'availableBalance' in root) {
-    return result as T;
-  }
-  return undefined;
+  return extractMauBalance<T>(result);
 }
 
 /**

--- a/src/cmds/mau/helpers.ts
+++ b/src/cmds/mau/helpers.ts
@@ -23,11 +23,57 @@ export function normalizeToArray<T extends object>(value: unknown): T[] {
   return [];
 }
 
+function readNamedField(source: unknown, field: string): unknown {
+  if (!source || typeof source !== 'object' || Array.isArray(source)) {
+    return undefined;
+  }
+  const record = source as Record<string, unknown>;
+  if (field in record) {
+    return record[field];
+  }
+  const capitalized = field.charAt(0).toUpperCase() + field.slice(1);
+  if (capitalized in record) {
+    return record[capitalized];
+  }
+  return undefined;
+}
+
 /**
  * Extracts the accounts list from a Mauritius getAccounts response.
+ * Supports `{ data: { accounts } }`, top-level `{ accounts }`, and singleton objects.
  * @param result - Raw getAccounts response
  */
 export function extractMauAccounts<T extends object>(result: unknown): T[] {
+  if (!result || typeof result !== 'object') {
+    return [];
+  }
+  const root = result as { data?: unknown };
+  const data = root.data;
+
+  if (Array.isArray(data)) {
+    return data as T[];
+  }
+
+  const nestedAccounts = readNamedField(data, 'accounts');
+  if (nestedAccounts !== undefined) {
+    return normalizeToArray<T>(nestedAccounts);
+  }
+
+  const topLevelAccounts = readNamedField(result, 'accounts');
+  if (topLevelAccounts !== undefined) {
+    return normalizeToArray<T>(topLevelAccounts);
+  }
+
+  return [];
+}
+
+/**
+ * Extracts a named list field from MAU list responses.
+ * Tries `data[field]`, then top-level `field`.
+ * @param result - Raw API response
+ * @param field - Field name (e.g. transactions)
+ */
+export function extractMauDataList<T extends object>(result: unknown, field: string): T[] {
   if (!result || typeof result !== 'object') {
     return [];
   }
@@ -35,31 +81,41 @@ export function extractMauAccounts<T extends object>(result: unknown): T[] {
   if (Array.isArray(data)) {
     return data as T[];
   }
-  if (data && typeof data === 'object') {
-    const accounts =
-      (data as { accounts?: unknown; Accounts?: unknown }).accounts ??
-      (data as { Accounts?: unknown }).Accounts;
-    if (accounts !== undefined) {
-      return normalizeToArray<T>(accounts);
-    }
+
+  const nested = readNamedField(data, field);
+  if (nested !== undefined) {
+    return normalizeToArray<T>(nested);
   }
+
+  const topLevel = readNamedField(result, field);
+  if (topLevel !== undefined) {
+    return normalizeToArray<T>(topLevel);
+  }
+
   return [];
 }
 
 /**
- * Extracts a named list field from `{ data: { [field]: ... } }` responses.
+ * Extracts a single MAU record (e.g. balance) from `{ data: {...} }` or a bare object.
  * @param result - Raw API response
- * @param field - Field name under `data` (e.g. transactions)
  */
-export function extractMauDataList<T extends object>(result: unknown, field: string): T[] {
-  if (!result || typeof result !== 'object') {
-    return [];
+export function extractMauRecord<T extends object>(result: unknown): T | undefined {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) {
+    return undefined;
   }
   const data = (result as { data?: unknown }).data;
-  if (!data || typeof data !== 'object' || Array.isArray(data)) {
-    return Array.isArray(data) ? (data as T[]) : [];
+  if (data && typeof data === 'object' && !Array.isArray(data)) {
+    // Prefer nested data when it looks like the record (not a list wrapper)
+    const record = data as Record<string, unknown>;
+    if (!('accounts' in record) && !('transactions' in record)) {
+      return data as T;
+    }
   }
-  return normalizeToArray<T>((data as Record<string, unknown>)[field]);
+  const root = result as Record<string, unknown>;
+  if ('accountNumber' in root || 'balance' in root || 'availableBalance' in root) {
+    return result as T;
+  }
+  return undefined;
 }
 
 /**

--- a/src/cmds/mau/helpers.ts
+++ b/src/cmds/mau/helpers.ts
@@ -2,6 +2,67 @@ import { CliError, ERROR_CODES } from '../../errors.js';
 import { readStdin } from '../../utils.js';
 
 /**
+ * Coerces API list payloads into a real array.
+ * Handles singleton objects (common when APIs serialize one-item lists as objects).
+ * @param value - Candidate list value from an API response
+ */
+export function normalizeToArray<T extends object>(value: unknown): T[] {
+  if (Array.isArray(value)) {
+    return value as T[];
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    // XML-style wrappers: { account: [...] } / { account: {...} }
+    for (const key of ['account', 'transaction', 'documentInformation', 'document']) {
+      if (key in record) {
+        return normalizeToArray<T>(record[key]);
+      }
+    }
+    return [value as T];
+  }
+  return [];
+}
+
+/**
+ * Extracts the accounts list from a Mauritius getAccounts response.
+ * @param result - Raw getAccounts response
+ */
+export function extractMauAccounts<T extends object>(result: unknown): T[] {
+  if (!result || typeof result !== 'object') {
+    return [];
+  }
+  const data = (result as { data?: unknown }).data;
+  if (Array.isArray(data)) {
+    return data as T[];
+  }
+  if (data && typeof data === 'object') {
+    const accounts =
+      (data as { accounts?: unknown; Accounts?: unknown }).accounts ??
+      (data as { Accounts?: unknown }).Accounts;
+    if (accounts !== undefined) {
+      return normalizeToArray<T>(accounts);
+    }
+  }
+  return [];
+}
+
+/**
+ * Extracts a named list field from `{ data: { [field]: ... } }` responses.
+ * @param result - Raw API response
+ * @param field - Field name under `data` (e.g. transactions)
+ */
+export function extractMauDataList<T extends object>(result: unknown, field: string): T[] {
+  if (!result || typeof result !== 'object') {
+    return [];
+  }
+  const data = (result as { data?: unknown }).data;
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return Array.isArray(data) ? (data as T[]) : [];
+  }
+  return normalizeToArray<T>((data as Record<string, unknown>)[field]);
+}
+
+/**
  * Resolves a MAU account ID from an argument or stdin JSON/plain text.
  * @param accountId - Optional account ID argument
  * @returns Resolved account ID string (may still need validation)

--- a/src/cmds/mau/transactions.ts
+++ b/src/cmds/mau/transactions.ts
@@ -11,7 +11,7 @@ import {
   withSpinner,
 } from '../../utils.js';
 import type { MauOptions } from '../types.js';
-import { resolveMauAccountId } from './helpers.js';
+import { extractMauDataList, resolveMauAccountId } from './helpers.js';
 
 interface MauTransactionsOptions extends MauOptions {
   from?: string;
@@ -56,7 +56,7 @@ export async function mauTransactionsCommand(accountId: string, options: MauTran
       maxRetries: 3,
       verbose,
     });
-    transactions = result.data.transactions;
+    transactions = extractMauDataList(result, 'transactions');
   });
 
   await runListCommand({

--- a/src/utils/command-runners.ts
+++ b/src/utils/command-runners.ts
@@ -40,7 +40,7 @@ export async function runListCommand<TFull, TSimple = TFull>(
 ): Promise<void> {
   const { isPiped, items, outputOptions, emptyMessage, countMessage, mapSimple } = options;
 
-  if (!items || items.length === 0) {
+  if (!Array.isArray(items) || items.length === 0) {
     if (!isPiped) {
       console.log(emptyMessage);
     } else {

--- a/test/cmds/mau.test.ts
+++ b/test/cmds/mau.test.ts
@@ -91,6 +91,26 @@ describe('mau commands', () => {
     );
   });
 
+  it('mauAccountsCommand normalizes a singleton accounts object', async () => {
+    const account = {
+      accountId: 5331,
+      accountNumber: '10101010101',
+      accountName: 'USD',
+      accountCurrency: 'USD',
+      profileId: 1,
+      profileName: 'Mock',
+    };
+    mockApi.getAccounts.mockResolvedValue({ data: { accounts: account } });
+
+    await mauAccountsCommand(baseOptions);
+
+    expect(runListCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [account],
+      })
+    );
+  });
+
   it('mauBalancesCommand fetches balances for a numeric account id', async () => {
     mockApi.getAccountBalances.mockResolvedValue({
       data: {

--- a/test/utils/mau-helpers.test.ts
+++ b/test/utils/mau-helpers.test.ts
@@ -1,0 +1,51 @@
+/// <reference types="vitest" />
+
+import { describe, expect, it } from 'vitest';
+import {
+  extractMauAccounts,
+  extractMauDataList,
+  normalizeToArray,
+} from '../../src/cmds/mau/helpers';
+
+describe('MAU response normalization', () => {
+  it('normalizeToArray keeps arrays', () => {
+    expect(normalizeToArray([{ a: 1 }])).toEqual([{ a: 1 }]);
+  });
+
+  it('normalizeToArray wraps singleton objects', () => {
+    expect(normalizeToArray({ accountId: 5331, accountNumber: '1' })).toEqual([
+      { accountId: 5331, accountNumber: '1' },
+    ]);
+  });
+
+  it('normalizeToArray unwraps XML-style account wrappers', () => {
+    expect(normalizeToArray({ account: { accountId: 1 } })).toEqual([{ accountId: 1 }]);
+    expect(normalizeToArray({ account: [{ accountId: 1 }, { accountId: 2 }] })).toEqual([
+      { accountId: 1 },
+      { accountId: 2 },
+    ]);
+  });
+
+  it('extractMauAccounts reads data.accounts arrays', () => {
+    const accounts = [{ accountId: 1 }, { accountId: 2 }];
+    expect(extractMauAccounts({ data: { accounts } })).toEqual(accounts);
+  });
+
+  it('extractMauAccounts wraps a singleton accounts object', () => {
+    const account = { accountId: 5331, accountNumber: '1010', accountCurrency: 'USD' };
+    expect(extractMauAccounts({ data: { accounts: account } })).toEqual([account]);
+  });
+
+  it('extractMauAccounts accepts data as a bare array', () => {
+    const accounts = [{ accountId: 1 }];
+    expect(extractMauAccounts({ data: accounts })).toEqual(accounts);
+  });
+
+  it('extractMauDataList reads nested list fields', () => {
+    const transactions = [{ amount: 10 }];
+    expect(extractMauDataList({ data: { transactions } }, 'transactions')).toEqual(transactions);
+    expect(extractMauDataList({ data: { transactions: { amount: 5 } } }, 'transactions')).toEqual([
+      { amount: 5 },
+    ]);
+  });
+});

--- a/test/utils/mau-helpers.test.ts
+++ b/test/utils/mau-helpers.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   extractMauAccounts,
+  extractMauBalance,
   extractMauDataList,
   extractMauRecord,
   normalizeToArray,
@@ -66,5 +67,18 @@ describe('MAU response normalization', () => {
     const balance = { accountNumber: '1', balance: 10, availableBalance: 9 };
     expect(extractMauRecord({ data: balance })).toEqual(balance);
     expect(extractMauRecord(balance)).toEqual(balance);
+  });
+
+  it('extractMauBalance unwraps accounts.balance nesting', () => {
+    const balance = {
+      accountNumber: '10101010101',
+      accountType: 'CALL DEPOSIT',
+      availableBalance: 100,
+      balance: 200,
+      currency: 'USD',
+    };
+    expect(extractMauBalance({ accounts: { balance } })).toEqual(balance);
+    expect(extractMauBalance({ data: { accounts: { balance } } })).toEqual(balance);
+    expect(extractMauBalance({ data: { balance } })).toEqual(balance);
   });
 });

--- a/test/utils/mau-helpers.test.ts
+++ b/test/utils/mau-helpers.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   extractMauAccounts,
   extractMauDataList,
+  extractMauRecord,
   normalizeToArray,
 } from '../../src/cmds/mau/helpers';
 
@@ -41,11 +42,29 @@ describe('MAU response normalization', () => {
     expect(extractMauAccounts({ data: accounts })).toEqual(accounts);
   });
 
+  it('extractMauAccounts reads top-level accounts without a data wrapper', () => {
+    const accounts = [{ accountId: 1 }, { accountId: 2 }];
+    expect(extractMauAccounts({ accounts })).toEqual(accounts);
+    expect(extractMauAccounts({ accounts: { accountId: 9 } })).toEqual([{ accountId: 9 }]);
+  });
+
   it('extractMauDataList reads nested list fields', () => {
     const transactions = [{ amount: 10 }];
     expect(extractMauDataList({ data: { transactions } }, 'transactions')).toEqual(transactions);
     expect(extractMauDataList({ data: { transactions: { amount: 5 } } }, 'transactions')).toEqual([
       { amount: 5 },
     ]);
+  });
+
+  it('extractMauDataList reads top-level list fields', () => {
+    expect(extractMauDataList({ transactions: [{ amount: 1 }] }, 'transactions')).toEqual([
+      { amount: 1 },
+    ]);
+  });
+
+  it('extractMauRecord reads data or bare balance objects', () => {
+    const balance = { accountNumber: '1', balance: 10, availableBalance: 9 };
+    expect(extractMauRecord({ data: balance })).toEqual(balance);
+    expect(extractMauRecord(balance)).toEqual(balance);
   });
 });


### PR DESCRIPTION
## Summary
- Normalize live Mauritius API payloads (singleton lists, missing `data` wrapper, `accounts.balance` nesting) so `mau accounts` / `balances` / related commands render correctly
- Bump CLI to **0.10.1** and `investec-mau-api` to **^0.1.1**

Follow-up to #47 with fixes found during live MAU testing.

## Test plan
- [ ] `npm run test:run` passes
- [ ] On a MAU-capable system: `ipb mau accounts` (no `rows.map` crash)
- [ ] `ipb mau accounts --json` returns an array of account objects
- [ ] `ipb mau balances <id> --json` returns flat balance fields (not `{ accounts: { balance: … } }`)
- [ ] `ipb mau transactions <id> --from … --to …` works with live date range


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of account, balance, document, and transaction responses so more API response shapes display correctly.
  * Document listings now handle missing account numbers more safely.
  * Empty or non-list results are now treated consistently, reducing unexpected output.

* **Tests**
  * Expanded coverage for response normalization across account, balance, document, and transaction flows.

* **Chores**
  * Updated the app version and refreshed a dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->